### PR TITLE
Negative bleed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>printability-validator</artifactId>
-    <version>2.1</version>
+    <version>2.2-SNAPSHOT</version>
     <name>Digipost Printability Validator</name>
     <description>Library for validating 'printability' of documents.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/printability-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/printability-validator.git</developerConnection>
         <url>https://github.com/digipost/printability-validator</url>
-        <tag>2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>printability-validator</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.1</version>
     <name>Digipost Printability Validator</name>
     <description>Library for validating 'printability' of documents.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/printability-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/printability-validator.git</developerConnection>
         <url>https://github.com/digipost/printability-validator</url>
-        <tag>HEAD</tag>
+        <tag>2.1</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>printability-validator</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.2</version>
     <name>Digipost Printability Validator</name>
     <description>Library for validating 'printability' of documents.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/printability-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/printability-validator.git</developerConnection>
         <url>https://github.com/digipost/printability-validator</url>
-        <tag>HEAD</tag>
+        <tag>2.2</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>printability-validator</artifactId>
-    <version>2.2</version>
+    <version>2.3-SNAPSHOT</version>
     <name>Digipost Printability Validator</name>
     <description>Library for validating 'printability' of documents.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/printability-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/printability-validator.git</developerConnection>
         <url>https://github.com/digipost/printability-validator</url>
-        <tag>2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -33,9 +33,8 @@ public enum PdfValidationError {
             + PdfValidator.BARCODE_AREA_WIDTH_MM + " mm."),
     PDF_PARSE_ERROR("Could not parse the PDF document."),
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
-    UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are A4 (" + PdfValidator.A4_WIDTH_MM + " mm x "
-            + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of %s mm for both dimensions and larger sizes up to a limit of %s for both dimensions. " +
-            "If these limits should be changed, contact digipost support."),
+    UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are width between %s - %s mm and height between "
+            + "%s - %s mm). If these limits should be changed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -33,8 +33,8 @@ public enum PdfValidationError {
             + PdfValidator.BARCODE_AREA_WIDTH_MM + " mm."),
     PDF_PARSE_ERROR("Could not parse the PDF document."),
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
-    UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are width between %s - %s mm and height between "
-            + "%s - %s mm. If these limits should be changed, contact digipost support."),
+    UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are width between %s—%s mm and height between "
+            + "%s—%s mm. If these limits should be changed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -34,7 +34,7 @@ public enum PdfValidationError {
     PDF_PARSE_ERROR("Could not parse the PDF document."),
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
     UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are width between %s - %s mm and height between "
-            + "%s - %s mm). If these limits should be changed, contact digipost support."),
+            + "%s - %s mm. If these limits should be changed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -34,7 +34,8 @@ public enum PdfValidationError {
     PDF_PARSE_ERROR("Could not parse the PDF document."),
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
     UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are A4 (" + PdfValidator.A4_WIDTH_MM + " mm x "
-            + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of " + PdfValidationSettings.DEFAULT_NEGATIVE_BLEED_MM + " mm for both dimensions. If more flexibility is needed, contact digipost support."),
+            + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of %s mm for both dimensions and larger sizes up to a limit of %s for both dimensions. " +
+            "If more flexibility is needed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -35,7 +35,7 @@ public enum PdfValidationError {
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
     UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are A4 (" + PdfValidator.A4_WIDTH_MM + " mm x "
             + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of %s mm for both dimensions and larger sizes up to a limit of %s for both dimensions. " +
-            "If more flexibility is needed, contact digipost support."),
+            "If these limits should be changed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationError.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationError.java
@@ -34,7 +34,7 @@ public enum PdfValidationError {
     PDF_PARSE_ERROR("Could not parse the PDF document."),
     PDF_PARSE_PAGE_ERROR("Could not parse at least one of the pages in the PDF document"),
     UNSUPPORTED_DIMENSIONS("The dimensions of the PDF document are not supported. Supported dimensions are A4 (" + PdfValidator.A4_WIDTH_MM + " mm x "
-            + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of " + PdfValidator.ALLOWED_NEGATIVE_DEVIATION_FROM_PDF_STANDARD_DIMENSIONS_MM + " mm for both dimensions"),
+            + PdfValidator.A4_HEIGHT_MM + " mm). For flexibility, we allow smaller sizes down to a limit of " + PdfValidationSettings.DEFAULT_NEGATIVE_BLEED_MM + " mm for both dimensions. If more flexibility is needed, contact digipost support."),
     REFERENCES_INVALID_FONT("The document refers to a non-standard font that is not included in the PDF."),
     DOCUMENT_TOO_SMALL("The PDF document size is too small."),
     INVALID_PDF("The PDF document is invalid."),

--- a/src/main/java/no/digipost/print/validate/PdfValidationResult.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationResult.java
@@ -57,8 +57,8 @@ public final class PdfValidationResult {
             for (PdfValidationError printPdfValideringsFeil : errors) {
                 final String err;
                 if(printPdfValideringsFeil == PdfValidationError.UNSUPPORTED_DIMENSIONS) {
-                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM,
-                            PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM);
+                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM,
+                            PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM);
                 } else {
                     err = printPdfValideringsFeil.toString();
                 }

--- a/src/main/java/no/digipost/print/validate/PdfValidationResult.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationResult.java
@@ -57,7 +57,8 @@ public final class PdfValidationResult {
             for (PdfValidationError printPdfValideringsFeil : errors) {
                 final String err;
                 if(printPdfValideringsFeil == PdfValidationError.UNSUPPORTED_DIMENSIONS) {
-                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), bleed.negativeBleedInMM, bleed.positiveBleedInMM);
+                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM,
+                            PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM);
                 } else {
                     err = printPdfValideringsFeil.toString();
                 }

--- a/src/main/java/no/digipost/print/validate/PdfValidationResult.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationResult.java
@@ -19,22 +19,26 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.unmodifiableList;
+import static no.digipost.print.validate.PdfValidationSettings.*;
+import static no.digipost.print.validate.PdfValidationSettings.DEFAULT_POSITIVE_BLEED_MM;
 
 public final class PdfValidationResult {
 
-    public static final PdfValidationResult EVERYTHING_OK = new PdfValidationResult(Collections.<PdfValidationError>emptyList(), -1);
+    public static final PdfValidationResult EVERYTHING_OK = new PdfValidationResult(Collections.<PdfValidationError>emptyList(), -1, new Bleed(DEFAULT_POSITIVE_BLEED_MM, DEFAULT_NEGATIVE_BLEED_MM));
 
     public final List<PdfValidationError> errors;
+    public final Bleed bleed;
     public final boolean okForPrint;
     public final boolean okForWeb;
     public final int pages;
 
 
-    PdfValidationResult(List<PdfValidationError> errors, int pages) {
+    PdfValidationResult(List<PdfValidationError> errors, int pages, Bleed bleed) {
         this.pages = pages;
         this.errors = errors != null ? unmodifiableList(errors) : Collections.<PdfValidationError>emptyList();
         this.okForPrint = PdfValidationError.OK_FOR_PRINT.containsAll(this.errors);
         this.okForWeb = PdfValidationError.OK_FOR_WEB.containsAll(this.errors);
+        this.bleed = bleed;
     }
 
     public boolean hasErrors() {
@@ -51,7 +55,13 @@ public final class PdfValidationResult {
             StringBuilder sb = new StringBuilder("[");
             sb.append(getClass().getSimpleName());
             for (PdfValidationError printPdfValideringsFeil : errors) {
-                PdfValidationError err = printPdfValideringsFeil;
+                final String err;
+                if(printPdfValideringsFeil == PdfValidationError.UNSUPPORTED_DIMENSIONS) {
+                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), bleed.negativeBleedInMM, bleed.positiveBleedInMM);
+                } else {
+                    err = printPdfValideringsFeil.toString();
+                }
+
                 sb.append(" ");
                 sb.append(err);
             }

--- a/src/main/java/no/digipost/print/validate/PdfValidationSettings.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationSettings.java
@@ -24,26 +24,44 @@ public class PdfValidationSettings {
     public final int maxNumberOfPages;
     public final boolean validatePDFversion;
     public static final int STANDARD_MAX_PAGES_FOR_AUTOMATED_PRINT = 14;
-    public static final int DEFAULT_BLEED_MM = 0;
-    public final int bleedInMM;
+    // The document is allowed to be x mm larger than a4 in width and height
+    public static final int DEFAULT_POSITIVE_BLEED_MM = 0;
+    // The document is allowed to be x mm smaller than a4 in width and height
+    public static final int DEFAULT_NEGATIVE_BLEED_MM = 10;
+    public final Bleed bleed;
 
-    public PdfValidationSettings(boolean validateLeftMargin, boolean validateFonts, boolean validateNumberOfPages, boolean validatePDFversion, int bleedInMM) {
-        this(validateLeftMargin, validateFonts, validateNumberOfPages, STANDARD_MAX_PAGES_FOR_AUTOMATED_PRINT, validatePDFversion, bleedInMM);
+    public PdfValidationSettings(boolean validateLeftMargin, boolean validateFonts, boolean validateNumberOfPages, boolean validatePDFversion,
+                                 int positiveBleedInMM, int negativeBleedInMM) {
+        this(validateLeftMargin, validateFonts, validateNumberOfPages, STANDARD_MAX_PAGES_FOR_AUTOMATED_PRINT, validatePDFversion,
+                positiveBleedInMM, negativeBleedInMM);
     }
 
     public PdfValidationSettings(boolean validateLeftMargin, boolean validateFonts, boolean validateNumberOfPages, boolean validatePDFversion) {
-        this(validateLeftMargin, validateFonts, validateNumberOfPages, STANDARD_MAX_PAGES_FOR_AUTOMATED_PRINT, validatePDFversion, DEFAULT_BLEED_MM);
+        this(validateLeftMargin, validateFonts, validateNumberOfPages, STANDARD_MAX_PAGES_FOR_AUTOMATED_PRINT, validatePDFversion,
+                DEFAULT_POSITIVE_BLEED_MM, DEFAULT_NEGATIVE_BLEED_MM);
     }
 
-    public PdfValidationSettings(boolean validateLeftMargin, boolean validateFonts, boolean validateNumberOfPages, int maxNumberOfPages, boolean validatePDFversion, int bleedInMM) {
+    public PdfValidationSettings(boolean validateLeftMargin, boolean validateFonts, boolean validateNumberOfPages, int maxNumberOfPages,
+                                 boolean validatePDFversion, int positiveBleedInMM, int negativeBleedInMM) {
         this.validateLeftMargin = validateLeftMargin;
         this.validateFonts = validateFonts;
         this.validateNumberOfPages = validateNumberOfPages;
         this.maxNumberOfPages = maxNumberOfPages;
         this.validatePDFversion = validatePDFversion;
-        this.bleedInMM = bleedInMM;
+        this.bleed = new Bleed(positiveBleedInMM, negativeBleedInMM);
     }
 
     public static final PdfValidationSettings CHECK_ALL = new PdfValidationSettings(true, true, true, true);
+
+    public static class Bleed {
+
+        public final int positiveBleedInMM;
+        public final int negativeBleedInMM;
+
+        public Bleed(int positiveBleedInMM, int negativeBleedInMM) {
+            this.positiveBleedInMM = positiveBleedInMM;
+            this.negativeBleedInMM = negativeBleedInMM;
+        }
+    }
 
 }

--- a/src/main/java/no/digipost/print/validate/PdfValidator.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidator.java
@@ -98,7 +98,7 @@ public class PdfValidator {
                 LOG.debug(e.getMessage(), e);
             }
 
-            return new PdfValidationResult(errors, numberOfPages);
+            return new PdfValidationResult(errors, numberOfPages, printValidationSettings.bleed);
         } finally {
             IOUtils.closeQuietly(pdfStream);
         }

--- a/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
+++ b/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
@@ -74,7 +74,7 @@ public class PrintPdfValidatorTest {
         String errorString = pdfValidationResult.toString();
 
         assertThat(errorString, is("[" + PdfValidationResult.class.getSimpleName() + " " + String.format(UNSUPPORTED_DIMENSIONS.message,
-                PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM, PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM) + "]"));
+                PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM, PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM) + "]"));
     }
 
     @Test

--- a/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
+++ b/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
@@ -73,7 +73,8 @@ public class PrintPdfValidatorTest {
 
         String errorString = pdfValidationResult.toString();
 
-        assertThat(errorString, is("[" + PdfValidationResult.class.getSimpleName() + " " + String.format(UNSUPPORTED_DIMENSIONS.message, bleed.negativeBleedInMM, bleed.positiveBleedInMM) + "]"));
+        assertThat(errorString, is("[" + PdfValidationResult.class.getSimpleName() + " " + String.format(UNSUPPORTED_DIMENSIONS.message,
+                PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM, PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM) + "]"));
     }
 
     @Test

--- a/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
+++ b/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
@@ -119,8 +119,13 @@ public class PrintPdfValidatorTest {
     }
 
     @Test
-    public void doesNotFailPDFLargerThatA4WhenBleedSettingIsActivated() {
-        assertThat(validationErrors("/pdf/a4-pdf-with-10mm-bleed.pdf", new PdfValidationSettings(true, true, true, true, 10)), empty());
+    public void doesNotFailPDFLargerThatA4WhenPositiveBleedSettingIsActivated() {
+        assertThat(validationErrors("/pdf/a4-pdf-with-10mm-bleed.pdf", new PdfValidationSettings(true, true, true, true, 10, 10)), empty());
+    }
+
+    @Test
+    public void doesNotFailPDFSmallerThanA4WhenNegativeBleedSettingIsActivated() {
+        assertThat(validationErrors("/pdf/letter-left-margin-20mm.pdf", new PdfValidationSettings(true, true, true, true, 10, 20)), empty());
     }
 
     @Test

--- a/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
+++ b/src/test/java/no/digipost/print/validate/PrintPdfValidatorTest.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.print.validate;
 
+import no.digipost.print.validate.PdfValidationSettings.Bleed;
 import org.junit.Test;
 
 import java.io.File;
@@ -63,6 +64,16 @@ public class PrintPdfValidatorTest {
     public void failsPdfWithInsufficientMarginForPrint() {
         assertThat(validationErrors("/pdf/far-from-a4-free-barcode-area.pdf", CHECK_ALL), contains(UNSUPPORTED_DIMENSIONS, INSUFFICIENT_MARGIN_FOR_PRINT));
         assertThat(validationErrors("/pdf/a4-full-page.pdf", CHECK_ALL), contains(INSUFFICIENT_MARGIN_FOR_PRINT));
+    }
+
+    @Test
+    public void failedPdfWithInsufficientMarginForPrintGivesPersonalizedBleedParameters() {
+        Bleed bleed = new Bleed(2, 3);
+        PdfValidationResult pdfValidationResult = new PdfValidationResult(validationErrors("/pdf/far-from-a4-free-barcode-area.pdf", new PdfValidationSettings(false, false, false, false, bleed.positiveBleedInMM, bleed.negativeBleedInMM)), 1, bleed);
+
+        String errorString = pdfValidationResult.toString();
+
+        assertThat(errorString, is("[" + PdfValidationResult.class.getSimpleName() + " " + String.format(UNSUPPORTED_DIMENSIONS.message, bleed.negativeBleedInMM, bleed.positiveBleedInMM) + "]"));
     }
 
     @Test


### PR DESCRIPTION
La till stötte för att kunna sätta en negativ bleed så man kan skicka in pdf:er som är MINDRE än A4.

La även till så att felmeldingen vid unsupported dimension lägger till virksomhetens bleed inställningar så man får en custom felmedling.