### PR TITLE
oppdater pdfbox til 2.0.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: trusty
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
fikser denne sårbarheten https://nvd.nist.gov/vuln/detail/CVE-2019-0228

- som vanlig har dependabot ikke klart å å oppdatere biblioteket 🤷‍♂️
- ~~travis støtter ikke lenger java8, som dette biblioteket krever, så bygget feiler 🤷‍♂️🤷‍♂️~~
- ~~det kan kanskje være grunnen til at dependabot feiler også? 🤷‍♂️🤷‍♂️🤷‍♂️~~