### PR TITLE
Adds method for PdfValidationResult to format validation error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Krav til PDF dokumenter er tilgjengelig på https://www.digipost.no/plattform/an
 
 Biblioteket er også tilgjengelig på [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22printability-validator%22).
 
+Feil ved validering av dimensjoner medfører `PdfValidationError` av typen `UNSUPPORTED_DIMENSIONS`.
+Den tilhørende meldingen inneholder variable parametre for margin og bleed. Fra og med versjon 3.3
+tilbyr `PdfValidationResult` en `formattedValidationErrorMessage`-metode for å kunne formatere denne
+feilmeldingen med riktig verdier. Denne formateringen skjedde tidligere kun i `PdfValidationResult`
+sin `toString`-metode. Den nevnte hjelpemetoden kan benyttes i sammenhenger det er er uønsket å
+benytte `toString`.
+
 ## For avsendere som sender til utskrift via offentlig Sikker Digital Post (SDP) meldingsformidlertjeneste.
 
 I SDP utskriftstjenesten er det satt opp en felles valideringskonfigurasjon. Den er som følger:

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
             <scope>test</scope>

--- a/src/main/java/no/digipost/print/validate/PdfValidationResult.java
+++ b/src/main/java/no/digipost/print/validate/PdfValidationResult.java
@@ -45,7 +45,19 @@ public final class PdfValidationResult {
         return !errors.isEmpty();
     }
 
-
+    public String formattedValidationErrorMessage(PdfValidationError validationError) {
+        if (validationError == PdfValidationError.UNSUPPORTED_DIMENSIONS) {
+            return String.format(
+                    PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(),
+                    PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM,
+                    PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM,
+                    PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM,
+                    PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM
+            );
+        } else {
+            return validationError.toString();
+        }
+    }
 
     private String toStringValue;
 
@@ -55,14 +67,7 @@ public final class PdfValidationResult {
             StringBuilder sb = new StringBuilder("[");
             sb.append(getClass().getSimpleName());
             for (PdfValidationError printPdfValideringsFeil : errors) {
-                final String err;
-                if(printPdfValideringsFeil == PdfValidationError.UNSUPPORTED_DIMENSIONS) {
-                    err = String.format(PdfValidationError.UNSUPPORTED_DIMENSIONS.toString(), PdfValidator.A4_WIDTH_MM - bleed.negativeBleedInMM,
-                            PdfValidator.A4_WIDTH_MM + bleed.positiveBleedInMM, PdfValidator.A4_HEIGHT_MM - bleed.negativeBleedInMM, PdfValidator.A4_HEIGHT_MM + bleed.positiveBleedInMM);
-                } else {
-                    err = printPdfValideringsFeil.toString();
-                }
-
+                final String err = formattedValidationErrorMessage(printPdfValideringsFeil);
                 sb.append(" ");
                 sb.append(err);
             }


### PR DESCRIPTION
PdfValiationErrors of type UNSUPPORTED_DIMENSIONS depend on the parent PdfValidationResult object to determine the appropriate string formatting values. This formatting is already performed in the toString()-metoden, however use of this method is not advisable in all contexts. The new implemented method allows for formatting the PdfValidationError using the appropriate bleed values